### PR TITLE
Add `ModalInput`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,0 +1,16 @@
+# textual-enhanced ChangeLog
+
+## Unreleased
+
+**Released: WiP**
+
+- Added `ModalInput`.
+  ([#3](https://github.com/davep/textual-enhanced/pull/3))
+
+## v0.1.0
+
+**Released: 2025-02-01**
+
+- Initial release.
+
+[//]: # (ChangeLog.md ends here)

--- a/README.md
+++ b/README.md
@@ -61,5 +61,9 @@ Mild style tweaks.
 
 ### `TextViewer`
 
+## Dialogs
+
+### `QuickInput`
+
 
 [//]: # (README.md ends here)

--- a/src/textual_enhanced/__main__.py
+++ b/src/textual_enhanced/__main__.py
@@ -2,12 +2,14 @@
 
 ##############################################################################
 # Textual imports.
+from textual import on, work
 from textual.app import ComposeResult
-from textual.widgets import Footer, Header
+from textual.widgets import Button, Footer, Header
 
 ##############################################################################
 # Textual Enhanced imports.
 from textual_enhanced.app import EnhancedApp
+from textual_enhanced.dialogs import ModalInput
 
 
 ##############################################################################
@@ -16,7 +18,16 @@ class DemoApp(EnhancedApp[None]):
 
     def compose(self) -> ComposeResult:
         yield Header()
+        yield Button("Quick input")
         yield Footer()
+
+    @on(Button.Pressed)
+    @work
+    async def demo_input(self) -> None:
+        if text := await self.push_screen_wait(
+            ModalInput(placeholder="Enter some text here")
+        ):
+            self.notify(f"Entered '{text}")
 
 
 ##############################################################################

--- a/src/textual_enhanced/dialogs/__init__.py
+++ b/src/textual_enhanced/dialogs/__init__.py
@@ -1,0 +1,12 @@
+"""Provides useful dialogs."""
+
+##############################################################################
+# Local imports.
+from .modal_input import ModalInput
+
+##############################################################################
+# Exports.
+__all__ = ["ModalInput"]
+
+
+### __init__.py ends here

--- a/src/textual_enhanced/dialogs/modal_input.py
+++ b/src/textual_enhanced/dialogs/modal_input.py
@@ -1,0 +1,57 @@
+"""A modal screen for quickly getting an input value."""
+
+##############################################################################
+# Textual imports.
+from textual import on
+from textual.app import ComposeResult
+from textual.screen import ModalScreen
+from textual.widgets import Input
+
+
+##############################################################################
+class ModalInput(ModalScreen[str | None]):
+    """A modal screen to get input from the user."""
+
+    CSS = """
+    ModalInput {
+        align: center middle;
+
+        Input, Input:focus {
+            border: round $border;
+            width: 60%;
+            padding: 1;
+            height: auto;
+        }
+    }
+    """
+
+    BINDINGS = [("escape", "escape")]
+
+    def __init__(
+        self, placeholder: str | None = None, classes: str | None = None
+    ) -> None:
+        """Initialise the object.
+
+        Args:
+            placeholder: The placeholder text to use.
+            classes: The CSS classes of the modal input.
+        """
+        super().__init__(classes=classes)
+        self._placeholder = placeholder or ""
+        """The placeholder to use for the input."""
+
+    def compose(self) -> ComposeResult:
+        """Compose the input dialog."""
+        yield Input(placeholder=self._placeholder)
+
+    @on(Input.Submitted)
+    def search(self) -> None:
+        """Accept the input."""
+        self.dismiss(self.query_one(Input).value.strip())
+
+    def action_escape(self) -> None:
+        """Escape out without getting the input."""
+        self.dismiss(None)
+
+
+### modal_input.py ends here


### PR DESCRIPTION
Adds a modal screen that's useful for quickly getting modal input.

Eg:

```python
@on(Button.Pressed)
@work
async def get_something(self) -> None:
    if text := await self.push_screen_wait(
        ModalInput(placeholder="Enter some text here")
    ):
        self.notify(f"Entered '{text}")
```

Closes #2.
