### PR TITLE
Adds a default help dialog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,10 @@
 
 - Added `ModalInput`.
   ([#3](https://github.com/davep/textual-enhanced/pull/3))
+- Added `HelpScreen`.
+  ([#5](https://github.com/davep/textual-enhanced/pull/5))
+- Added common command messages and a common command provider.
+  ([#5](https://github.com/davep/textual-enhanced/pull/5))
 
 ## v0.1.0
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,12 @@ Mild style tweaks.
 
 ## Dialogs
 
+### `HelpScreen`
+
+TODO: Explain.
+
 ### `QuickInput`
 
+TODO: Explain.
 
 [//]: # (README.md ends here)

--- a/src/textual_enhanced/__main__.py
+++ b/src/textual_enhanced/__main__.py
@@ -8,13 +8,44 @@ from textual.widgets import Button, Footer, Header
 
 ##############################################################################
 # Textual Enhanced imports.
+from textual_enhanced import __version__
 from textual_enhanced.app import EnhancedApp
-from textual_enhanced.dialogs import ModalInput
+from textual_enhanced.commands import Command, CommonCommands, Help, Quit
+from textual_enhanced.dialogs import HelpScreen, ModalInput
 
 
 ##############################################################################
 class DemoApp(EnhancedApp[None]):
     """A little demo app."""
+
+    HELP_TITLE = f"textual-enhanced v{__version__}"
+    HELP_ABOUT = "A library of mildly-opinionated enhancements to Textual."
+    HELP_LICENSE = """MIT License
+
+    Copyright (c) 2025 Dave Pearson <davep@davep.org>
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+    IN THE SOFTWARE.
+    """
+
+    COMMAND_MESSAGES = {Help, Quit}
+    COMMANDS = {CommonCommands}
+    BINDINGS = Command.bindings(*COMMAND_MESSAGES)
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -28,6 +59,14 @@ class DemoApp(EnhancedApp[None]):
             ModalInput(placeholder="Enter some text here")
         ):
             self.notify(f"Entered '{text}")
+
+    @on(Help)
+    def action_help_command(self) -> None:
+        self.push_screen(HelpScreen())
+
+    @on(Quit)
+    def action_quit_command(self) -> None:
+        self.exit()
 
 
 ##############################################################################

--- a/src/textual_enhanced/commands/__init__.py
+++ b/src/textual_enhanced/commands/__init__.py
@@ -3,10 +3,19 @@
 ##############################################################################
 # Local imports.
 from .command import Command
+from .common import CommonCommands, Help, Quit
 from .provider import CommandHit, CommandHits, CommandsProvider
 
 ##############################################################################
 # Exports.
-__all__ = ["CommandHit", "CommandHits", "Command", "CommandsProvider"]
+__all__ = [
+    "CommandHit",
+    "CommandHits",
+    "Command",
+    "CommandsProvider",
+    "CommonCommands",
+    "Help",
+    "Quit",
+]
 
 ### __init__.py ends here

--- a/src/textual_enhanced/commands/common.py
+++ b/src/textual_enhanced/commands/common.py
@@ -1,0 +1,39 @@
+"""Command classes and a provider for common commands."""
+
+##############################################################################
+# Local imports.
+from .command import Command
+from .provider import CommandHit, CommandHits, CommandsProvider
+
+
+##############################################################################
+class Help(Command):
+    """Show help for and information about the application"""
+
+    BINDING_KEY = "f1, ?"
+    SHOW_IN_FOOTER = True
+
+
+##############################################################################
+class Quit(Command):
+    """Quit the application"""
+
+    BINDING_KEY = "f10, ctrl+q"
+    SHOW_IN_FOOTER = True
+
+
+##############################################################################
+class CommonCommands(CommandsProvider):
+    """Provides some common top-level commands for the application."""
+
+    def commands(self) -> CommandHits:
+        """Provide the main application commands for the command palette.
+
+        Yields:
+            The commands for the command palette.
+        """
+        yield Help()
+        yield Quit()
+
+
+### common.py ends here

--- a/src/textual_enhanced/dialogs/__init__.py
+++ b/src/textual_enhanced/dialogs/__init__.py
@@ -2,11 +2,12 @@
 
 ##############################################################################
 # Local imports.
+from .help import HelpScreen
 from .modal_input import ModalInput
 
 ##############################################################################
 # Exports.
-__all__ = ["ModalInput"]
+__all__ = ["HelpScreen", "ModalInput"]
 
 
 ### __init__.py ends here

--- a/src/textual_enhanced/dialogs/help.py
+++ b/src/textual_enhanced/dialogs/help.py
@@ -1,0 +1,147 @@
+"""Provides a simple help screen."""
+
+##############################################################################
+# Python imports.
+from inspect import cleandoc
+from operator import methodcaller
+from typing import Any
+from webbrowser import open as open_url
+
+##############################################################################
+# Textual imports.
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Center, Vertical, VerticalScroll
+from textual.dom import DOMNode
+from textual.screen import ModalScreen, Screen
+from textual.widgets import Button, Markdown
+
+##############################################################################
+# Textual enhanced imports.
+from ..commands import Command
+
+
+##############################################################################
+class HelpScreen(ModalScreen[None]):
+    """The help screen."""
+
+    CSS = """
+    HelpScreen {
+        align: center middle;
+
+        &> Vertical {
+            width: 75%;
+            height: 90%;
+            background: $panel;
+            border: solid $border;
+        }
+
+        Markdown, MarkdownTable {
+            padding: 0 1 0 1;
+            background: transparent;
+        }
+
+        MarkdownH1 {
+            padding: 1 0 1 0;
+            background: $foreground 10%;
+        }
+
+        VerticalScroll {
+            scrollbar-gutter: stable;
+            scrollbar-background: $panel;
+            scrollbar-background-hover: $panel;
+            scrollbar-background-active: $panel;
+        }
+
+        Center {
+            height: auto;
+            width: 100%;
+            border-top: solid $border;
+        }
+    }
+    """
+
+    BINDINGS = [("escape, f1", "close")]
+
+    def __init__(self, help_for: Screen[Any] | None = None) -> None:
+        """Initialise the help screen.
+
+        Args:
+            help_for: The screen to show the help for.
+        """
+        super().__init__()
+        if help_for is None:
+            help_for = self.app.screen
+        self._context_help = ""
+        for node in (
+            help_for.focused if help_for.focused is not None else help_for
+        ).ancestors_with_self:
+            if node.HELP is not None:
+                self._context_help += f"\n\n{cleandoc(node.HELP)}"
+            self._context_help += self.command_help(node)
+
+    def _all_keys(self, command: Command) -> str:
+        """Render all the keys for the given command.
+
+        Args:
+            command: The command to get all the keys for.
+
+        Returns:
+            A string listing all the keys for the command.
+        """
+        return ", ".join(
+            self.app.get_key_display(Binding(key.strip(), ""))
+            for key in command.binding().key.split(",")
+        )
+
+    def command_help(self, node: DOMNode) -> str:
+        """Build help from the commands provided by a DOM node.
+
+        Args:
+            node: The node that might provide commands
+
+        Returns:
+            The help text.
+        """
+        if (commands := getattr(node, "COMMAND_MESSAGES", None)) is None:
+            return ""
+        keys = "| Command | Key | Description |\n| - | - | - |\n"
+        for command in sorted(commands, key=methodcaller("command")):
+            keys += f"| {command.command()} | {self._all_keys(command)} | {command.tooltip()} |\n"
+        return f"\n\n{keys}"
+
+    @property
+    def _template(self) -> str:
+        """The template for the help text."""
+        template = ""
+        if title := getattr(self.app, "HELP_TITLE", ""):
+            template += f"# {cleandoc(title)}\n\n"
+        template += "{context_help}\n\n"
+        if about := getattr(self.app, "HELP_ABOUT", ""):
+            template += f"## About\n\n{cleandoc(about)}\n\n"
+        if license := getattr(self.app, "HELP_LICENSE", ""):
+            template += f"## License\n\n{cleandoc(license)}\n"
+        return template
+
+    def compose(self) -> ComposeResult:
+        """Compose the layout of the help screen."""
+        with Vertical() as help_screen:
+            help_screen.border_title = "Help"
+            with VerticalScroll():
+                yield Markdown(self._template.format(context_help=self._context_help))
+            with Center():
+                yield Button("Okay [dim]\\[Esc]")
+
+    @on(Button.Pressed)
+    def action_close(self) -> None:
+        """Close the help screen."""
+        self.dismiss(None)
+
+    @on(Markdown.LinkClicked)
+    def visit(self, event: Markdown.LinkClicked) -> None:
+        """Visit any link clicked in the help."""
+        open_url(event.href)
+
+
+### help.py ends here


### PR DESCRIPTION
The recently-added help system in Textual is nicely done, but unfortunately it's a little hostile to keyboard-only use; which is unfortunate because it's intended to help people who want to know the key bindings they can use. So in my recent apps I've rolled my own help screen, which originally came from an idea that I had in Tinboard (which coincidentally implemented the help a little like Textual ended up doing so), with the aim of making help as keyboard-friendly as possible.

This approach also allows for a display of some general application information, as well as displaying the license (often a very good idea with many FOSS applications).

Closes #1.
