### PR TITLE
Add a Confirmation dialog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,7 @@
 
 **Released: WiP**
 
-- Added `Confirm`.
+- Added `Confirm`. ([#8](https://github.com/davep/textual-enhanced/pull/8))
 
 ## v0.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # textual-enhanced ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Added `Confirm`.
+
 ## v0.2.0
 
 **Released: 2025-02-02**

--- a/src/textual_enhanced/__main__.py
+++ b/src/textual_enhanced/__main__.py
@@ -11,7 +11,7 @@ from textual.widgets import Button, Footer, Header
 from textual_enhanced import __version__
 from textual_enhanced.app import EnhancedApp
 from textual_enhanced.commands import Command, CommonCommands, Help, Quit
-from textual_enhanced.dialogs import HelpScreen, ModalInput
+from textual_enhanced.dialogs import Confirm, HelpScreen, ModalInput
 
 
 ##############################################################################
@@ -49,16 +49,30 @@ class DemoApp(EnhancedApp[None]):
 
     def compose(self) -> ComposeResult:
         yield Header()
-        yield Button("Quick input")
+        yield Button("Quick input", id="input")
+        yield Button("Yes or no?", id="confirm")
         yield Footer()
 
-    @on(Button.Pressed)
+    @on(Button.Pressed, "#input")
     @work
-    async def demo_input(self) -> None:
+    async def input_action(self) -> None:
         if text := await self.push_screen_wait(
             ModalInput(placeholder="Enter some text here")
         ):
             self.notify(f"Entered '{text}")
+
+    @on(Button.Pressed, "#confirm")
+    @work
+    async def confirm_action(self) -> None:
+        self.notify(
+            "YES!"
+            if await self.push_screen_wait(
+                Confirm(
+                    "Well?", "So, what's the decision? Are we going with yes or no?"
+                )
+            )
+            else "No!"
+        )
 
     @on(Help)
     def action_help_command(self) -> None:

--- a/src/textual_enhanced/dialogs/__init__.py
+++ b/src/textual_enhanced/dialogs/__init__.py
@@ -2,12 +2,13 @@
 
 ##############################################################################
 # Local imports.
+from .confirm import Confirm
 from .help import HelpScreen
 from .modal_input import ModalInput
 
 ##############################################################################
 # Exports.
-__all__ = ["HelpScreen", "ModalInput"]
+__all__ = ["Confirm", "HelpScreen", "ModalInput"]
 
 
 ### __init__.py ends here

--- a/src/textual_enhanced/dialogs/confirm.py
+++ b/src/textual_enhanced/dialogs/confirm.py
@@ -1,0 +1,101 @@
+"""Provides a confirmation dialog."""
+
+##############################################################################
+# Textual imports.
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label
+
+
+##############################################################################
+class Confirm(ModalScreen[bool]):
+    """A modal dialog for confirming things."""
+
+    CSS = """
+    Confirm {
+        align: center middle;
+
+        &> Vertical {
+            padding: 1 2;
+            height: auto;
+            width: auto;
+            max-width: 80vw;
+            background: $surface;
+            border: panel $error;
+            border-title-color: $text;
+
+            &> Horizontal {
+                height: auto;
+                width: 100%;
+                align-horizontal: center;
+            }
+        }
+
+        Label {
+            width: auto;
+            max-width: 70vw;
+            padding-left: 1;
+            padding-right: 1;
+            margin-bottom: 1;
+        }
+
+        Button {
+            margin-right: 1;
+        }
+    }
+    """
+
+    BINDINGS = [
+        ("escape", "no"),
+        ("f2", "yes"),
+        ("left", "app.focus_previous"),
+        ("right", "app.focus_next"),
+    ]
+
+    def __init__(
+        self, title: str, question: str, yes_text: str = "Yes", no_text: str = "No"
+    ) -> None:
+        """Initialise the dialog.
+
+        Args:
+            title: The title for the dialog.
+            question: The question to ask the user.
+            yes_text: The text for the yes button.
+            no_text: The text for the no button.
+        """
+        super().__init__()
+        self._title = title
+        """The title for the dialog."""
+        self._question = question
+        """The question to ask the user."""
+        self._yes = yes_text
+        """The text of the yes button."""
+        self._no = no_text
+        """The text of the no button."""
+
+    def compose(self) -> ComposeResult:
+        """Compose the layout of the dialog."""
+        key_colour = (
+            "dim" if self.app.current_theme is None else self.app.current_theme.accent
+        )
+        with Vertical() as dialog:
+            dialog.border_title = self._title
+            yield Label(self._question)
+            with Horizontal():
+                yield Button(f"{self._no} [{key_colour}]\\[Esc][/]", id="no")
+                yield Button(f"{self._yes} [{key_colour}]\\[F2][/]", id="yes")
+
+    @on(Button.Pressed, "#yes")
+    def action_yes(self) -> None:
+        """Send back the positive response."""
+        self.dismiss(True)
+
+    @on(Button.Pressed, "#no")
+    def action_no(self) -> None:
+        """Send back the negative response."""
+        self.dismiss(False)
+
+
+### confirm.py ends here


### PR DESCRIPTION
Adds a pretty generic confirmation dialog. Common use is something like:

```python
@work
async def action_destructive_thing(self) -> None:
    if await self.app.push_screen_wait(
        Confirm(
            "Destroy?",
            "Are you really sure you want to do this very destructive thing? Like really sure?",
        )
    ):
        do_that_thing()
```
