### PR TITLE
Allow adding a key that's always dim

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # textual-enhanced ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Allow forcing `dim` when adding a key with `add_key`.
+
 ## v0.3.0
 
 **Released: 2025-02-03**

--- a/src/textual_enhanced/tools/add_key_name.py
+++ b/src/textual_enhanced/tools/add_key_name.py
@@ -11,7 +11,7 @@ from textual.widget import Widget
 
 
 ##############################################################################
-def add_key(label: str, key: str, context: App[Any] | Widget) -> str:
+def add_key(label: str, key: str, context: App[Any] | Widget | None = None) -> str:
     """Add a key name to a label.
 
     Args:
@@ -29,7 +29,9 @@ def add_key(label: str, key: str, context: App[Any] | Widget) -> str:
     if isinstance(context, Widget):
         context = context.app
     key_colour = (
-        "dim" if context.current_theme is None else context.current_theme.accent
+        "dim"
+        if context is None or context.current_theme is None
+        else context.current_theme.accent
     )
     return f"{label} [{key_colour}]\\[{key}][/]"
 


### PR DESCRIPTION
While I prefer to use accent for showing off a key in a label, there are times when I just want it to be `dim` (accent doesn't always play well with button variants, for example).