### PR TITLE
Tweak the command palette scrollbar

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # textual-enhanced ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Tweaked the styling of the command palette's scrollbar so it's less
+  intrusive.
+
 ## v0.4.0
 
 **Released: 2025-02-03**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 **Released: WiP**
 
 - Tweaked the styling of the command palette's scrollbar so it's less
-  intrusive.
+  intrusive. ([#14](https://github.com/davep/textual-enhanced/pull/14))
 
 ## v0.4.0
 

--- a/src/textual_enhanced/__main__.py
+++ b/src/textual_enhanced/__main__.py
@@ -1,18 +1,48 @@
 """A simple demo app of some of the enhancements."""
 
 ##############################################################################
+# Python imports.
+from dataclasses import dataclass
+
+##############################################################################
 # Textual imports.
 from textual import on, work
 from textual.app import ComposeResult
+from textual.message import Message
 from textual.widgets import Button, Footer, Header
 
 ##############################################################################
 # Textual Enhanced imports.
 from textual_enhanced import __version__
 from textual_enhanced.app import EnhancedApp
-from textual_enhanced.commands import Command, CommonCommands, Help, Quit
+from textual_enhanced.commands import (
+    Command,
+    CommandHit,
+    CommandHits,
+    CommandsProvider,
+    CommonCommands,
+    Help,
+    Quit,
+)
 from textual_enhanced.dialogs import Confirm, HelpScreen, ModalInput
 from textual_enhanced.screen import EnhancedScreen
+
+
+##############################################################################
+@dataclass
+class ShowNumber(Message):
+    number: int
+
+
+##############################################################################
+class NumberProvider(CommandsProvider):
+    def commands(self) -> CommandHits:
+        for n in range(500):
+            yield CommandHit(
+                f"This is the rather special and unique number {n}",
+                f"This is some help about the number {n}, just in case you needed it",
+                ShowNumber(n),
+            )
 
 
 ##############################################################################
@@ -25,6 +55,7 @@ class Main(EnhancedScreen[None]):
         yield Header()
         yield Button("Quick input", id="input")
         yield Button("Yes or no?", id="confirm")
+        yield Button("Pick a number", id="number")
         yield Footer()
 
     @on(Button.Pressed, "#input")
@@ -48,6 +79,10 @@ class Main(EnhancedScreen[None]):
             else "No!"
         )
 
+    @on(Button.Pressed, "#number")
+    def pick_a_number(self) -> None:
+        self.show_palette(NumberProvider)
+
     @on(Help)
     def action_help_command(self) -> None:
         self.app.push_screen(HelpScreen())
@@ -55,6 +90,10 @@ class Main(EnhancedScreen[None]):
     @on(Quit)
     def action_quit_command(self) -> None:
         self.app.exit()
+
+    @on(ShowNumber)
+    def show_the_number(self, number: ShowNumber) -> None:
+        self.notify(f"You picked {number.number}")
 
 
 ##############################################################################

--- a/src/textual_enhanced/app.py
+++ b/src/textual_enhanced/app.py
@@ -18,6 +18,11 @@ class EnhancedApp(Generic[ReturnType], App[ReturnType]):
     CommandPalette > Vertical {
         width: 75%; /* Full-width command palette looks kinda unfinished. Fix that. */
         background: $panel;
+        OptionList{
+            scrollbar-background: $panel;
+            scrollbar-background-hover: $panel;
+            scrollbar-background-active: $panel;
+        }
         SearchIcon {
             display: none;
         }


### PR DESCRIPTION
Tweak the styling of the scrollbar in the command palette so that it's less intrusive. The focus should be the actual content, not an eye-catching vertical line to the side.