### PR TITLE
Add `CommandsProvider.maybe`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # textual-enhanced ChangeLog
 
+## Unrelased
+
+**Released: WiP.***
+
+- Added `maybe` to `CommandsProvider`.
+
 ## v0.6.0
 
 **Released: 2025-02-12.***

--- a/src/textual_enhanced/commands/provider.py
+++ b/src/textual_enhanced/commands/provider.py
@@ -46,6 +46,23 @@ class CommandsProvider(Provider):
         """The prompt for the command provider."""
         return ""
 
+    def maybe(self, command: type[Command]) -> CommandHits:
+        """Yield a command if it's applicable.
+
+        Args:
+            command: The type of the command to maybe yield.
+
+        Yields:
+            The command if it can be used right now.
+
+        This method takes the command, looks at its `action_name` and uses
+        Textual's `check_action` to see if the action can be performed right
+        now. If it can it will `yield` an instance of the command, otherwise
+        it does nothing.
+        """
+        if self.screen.check_action(command.action_name(), ()):
+            yield command()
+
     @abstractmethod
     def commands(self) -> CommandHits:
         """Provide the command data for the command palette.


### PR DESCRIPTION
Adds a method that makes it easier to add a command to Textual's command palette only if the action can be performed at this moment.