### PR TITLE
Add support for "helpful bindings"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # textual-enhanced ChangeLog
 
+## Unreleased
+
+**Released: WiP***
+
+- Added the idea of a `HelpfulBinding`.
+  ([#27](https://github.com/davep/textual-enhanced/pull/27))
+
 ## v0.7.1
 
 **Released: 2025-03-07***

--- a/src/textual_enhanced/__main__.py
+++ b/src/textual_enhanced/__main__.py
@@ -15,6 +15,7 @@ from textual.widgets import Button, Footer, Header
 # Textual Enhanced imports.
 from textual_enhanced import __version__
 from textual_enhanced.app import EnhancedApp
+from textual_enhanced.binding import HelpfulBinding
 from textual_enhanced.commands import (
     ChangeTheme,
     Command,
@@ -50,7 +51,17 @@ class NumberProvider(CommandsProvider):
 class Main(EnhancedScreen[None]):
     COMMAND_MESSAGES = (Help, ChangeTheme, Quit)
     COMMANDS = {CommonCommands}
-    BINDINGS = Command.bindings(*COMMAND_MESSAGES)
+    BINDINGS = Command.bindings(
+        *COMMAND_MESSAGES,
+        HelpfulBinding(
+            "ctrl+y, ctrl+i",
+            "gndn",
+            show=False,
+            description="This is the description",
+            tooltip="This is the tooltip",
+        ),
+        HelpfulBinding("ctrl+t, ctrl+k", "gndn", description="This is the description"),
+    )
 
     def compose(self) -> ComposeResult:
         yield Header()

--- a/src/textual_enhanced/binding.py
+++ b/src/textual_enhanced/binding.py
@@ -1,0 +1,25 @@
+"""Provides an enhanced binding class."""
+
+##############################################################################
+# Textual imports.
+from textual.binding import Binding
+
+
+##############################################################################
+class HelpfulBinding(Binding):
+    """A binding that should show in the help screen.
+
+    In many cases a binding will be associated with a
+    [`Command`][textual_enhanced.commands.Command] and will show up in the
+    [help screen][textual_enhanced.dialogs.HelpScreen] anyway. But sometimes
+    there will be bindings that are particular to a widget that I want
+    highlighted, that I want called out in the help screen. On the other
+    hand I don't want *all* bindings to show in the help screen as that
+    would end up being a cluttered and unhelpful mess.
+
+    This class lets a binding be marked as helpful, destined for the help
+    screen.
+    """
+
+
+### binding.py ends here

--- a/src/textual_enhanced/binding.py
+++ b/src/textual_enhanced/binding.py
@@ -21,5 +21,10 @@ class HelpfulBinding(Binding):
     screen.
     """
 
+    @property
+    def most_helpful_description(self) -> str:
+        """The most helpful description possible."""
+        return self.tooltip or self.description
+
 
 ### binding.py ends here

--- a/src/textual_enhanced/dialogs/help.py
+++ b/src/textual_enhanced/dialogs/help.py
@@ -98,21 +98,6 @@ class HelpScreen(ModalScreen[None]):
             for key in binding.key.split(",")
         )
 
-    def binding_help(self, node: DOMNode) -> str:
-        """Build help from the bindings provided by a DOM node.
-
-        Args:
-            node: The node that might provide bindings.
-
-        Returns:
-            The help text.
-        """
-        bindings = ""
-        for binding in getattr(node, "BINDINGS", []):
-            if isinstance(binding, HelpfulBinding):
-                bindings += f"\n\n{binding}\n\n"
-        return f"\n\n{bindings}"
-
     def input_help(self, node: DOMNode) -> str:
         """Build help from the bindings and commands provided by a DOM node.
 

--- a/src/textual_enhanced/dialogs/help.py
+++ b/src/textual_enhanced/dialogs/help.py
@@ -3,7 +3,7 @@
 ##############################################################################
 # Python imports.
 from inspect import cleandoc
-from operator import methodcaller
+from operator import attrgetter, methodcaller
 from typing import Any
 from webbrowser import open as open_url
 
@@ -131,8 +131,10 @@ class HelpScreen(ModalScreen[None]):
         if not any((helpful_bindings, commands)):
             return ""
         keys = "| Command | Key | Description |\n| - | - | - |\n"
-        for binding in helpful_bindings:
-            keys += f"| | {self._all_keys(binding)} | {binding.tooltip or binding.description} |\n"
+        for binding in sorted(
+            helpful_bindings, key=attrgetter("most_helpful_description")
+        ):
+            keys += f"| | {self._all_keys(binding)} | {binding.most_helpful_description} |\n"
         for command in sorted(commands, key=methodcaller("command")):
             keys += f"| {command.command()} | {self._all_keys(command)} | {command.tooltip()} |\n"
         return f"\n\n{keys}"

--- a/src/textual_enhanced/dialogs/help.py
+++ b/src/textual_enhanced/dialogs/help.py
@@ -19,6 +19,7 @@ from textual.widgets import Button, Markdown
 
 ##############################################################################
 # Textual enhanced imports.
+from ..binding import HelpfulBinding
 from ..commands import Command
 from ..tools import add_key
 
@@ -80,24 +81,40 @@ class HelpScreen(ModalScreen[None]):
         ).ancestors_with_self:
             if node.HELP is not None:
                 self._context_help += f"\n\n{cleandoc(node.HELP)}"
-            self._context_help += self.command_help(node)
+            self._context_help += self.input_help(node)
 
-    def _all_keys(self, command: Command) -> str:
-        """Render all the keys for the given command.
+    def _all_keys(self, source: Command | Binding) -> str:
+        """Render all the keys for the given command or binding.
 
         Args:
-            command: The command to get all the keys for.
+            source: The command or binding to get the keys for.
 
         Returns:
-            A string listing all the keys for the command.
+            A string listing all the keys for the command or binding.
         """
+        binding = source if isinstance(source, Binding) else source.binding()
         return ", ".join(
             self.app.get_key_display(Binding(key.strip(), ""))
-            for key in command.binding().key.split(",")
+            for key in binding.key.split(",")
         )
 
-    def command_help(self, node: DOMNode) -> str:
-        """Build help from the commands provided by a DOM node.
+    def binding_help(self, node: DOMNode) -> str:
+        """Build help from the bindings provided by a DOM node.
+
+        Args:
+            node: The node that might provide bindings.
+
+        Returns:
+            The help text.
+        """
+        bindings = ""
+        for binding in getattr(node, "BINDINGS", []):
+            if isinstance(binding, HelpfulBinding):
+                bindings += f"\n\n{binding}\n\n"
+        return f"\n\n{bindings}"
+
+    def input_help(self, node: DOMNode) -> str:
+        """Build help from the bindings and commands provided by a DOM node.
 
         Args:
             node: The node that might provide commands
@@ -105,9 +122,17 @@ class HelpScreen(ModalScreen[None]):
         Returns:
             The help text.
         """
-        if (commands := getattr(node, "COMMAND_MESSAGES", None)) is None:
+        helpful_bindings = [
+            binding
+            for binding in getattr(node, "BINDINGS", [])
+            if isinstance(binding, HelpfulBinding)
+        ]
+        commands = getattr(node, "COMMAND_MESSAGES", [])
+        if not any((helpful_bindings, commands)):
             return ""
         keys = "| Command | Key | Description |\n| - | - | - |\n"
+        for binding in helpful_bindings:
+            keys += f"| | {self._all_keys(binding)} | {binding.tooltip or binding.description} |\n"
         for command in sorted(commands, key=methodcaller("command")):
             keys += f"| {command.command()} | {self._all_keys(command)} | {command.tooltip()} |\n"
         return f"\n\n{keys}"


### PR DESCRIPTION
Mostly I want the help screen to be populated with help for commands, most of which have bindings and so they document bindings too.

Here I add the concept of a `HelpfulBinding`; this is a binding that is called out as something that should also be shown in the help screen. This means that help isn't stuffed with *all* the bindings, but does call out non-command bindings that are important.