### PR TITLE
Improve how the binding table looks when it's just keys

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # textual-enhanced ChangeLog
 
+## v0.8.1
+
+**Released: 2025-03-15***
+
+- Made a cosmetic improvement to the binding table in the help screen if
+  there are no bindings associated with commands.
+
 ## v0.8.0
 
 **Released: 2025-03-15***

--- a/src/textual_enhanced/__main__.py
+++ b/src/textual_enhanced/__main__.py
@@ -47,6 +47,12 @@ class NumberProvider(CommandsProvider):
             )
 
 
+class HelpfulButton(Button):
+    BINDINGS = [
+        HelpfulBinding("ctrl+o", "gndn", description="This does nothing useful")
+    ]
+
+
 ##############################################################################
 class Main(EnhancedScreen[None]):
     COMMAND_MESSAGES = (Help, ChangeTheme, Quit)
@@ -65,7 +71,7 @@ class Main(EnhancedScreen[None]):
 
     def compose(self) -> ComposeResult:
         yield Header()
-        yield Button("Quick input", id="input")
+        yield HelpfulButton("Quick input", id="input")
         yield Button("Another input", id="input_with_default")
         yield Button("Yes or no?", id="confirm")
         yield Button("Pick a number", id="number")

--- a/src/textual_enhanced/dialogs/help.py
+++ b/src/textual_enhanced/dialogs/help.py
@@ -115,11 +115,11 @@ class HelpScreen(ModalScreen[None]):
         commands = getattr(node, "COMMAND_MESSAGES", [])
         if not any((helpful_bindings, commands)):
             return ""
-        keys = "| Command | Key | Description |\n| - | - | - |\n"
+        keys = f"{'| Command ' if commands else ''}| Key | Description |\n{'| - ' if commands else ''}| - | - |\n"
         for binding in sorted(
             helpful_bindings, key=attrgetter("most_helpful_description")
         ):
-            keys += f"| | {self._all_keys(binding)} | {binding.most_helpful_description} |\n"
+            keys += f"{'| ' if commands else ''}| {self._all_keys(binding)} | {binding.most_helpful_description} |\n"
         for command in sorted(commands, key=methodcaller("command")):
             keys += f"| {command.command()} | {self._all_keys(command)} | {command.tooltip()} |\n"
         return f"\n\n{keys}"


### PR DESCRIPTION
If there's no command in the table at all, don't show the command column.