### PR TITLE
Rename `ModalInput.search` to `ModalInput.accept_input`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # textual-enhanced ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Renamed `ModalInput.search` to `ModalInput.accept_input`.
+  ([#43](https://github.com/davep/textual-enhanced/issues/43))
+
 ## v0.11.0
 
 **Released: 2025-04-03**

--- a/src/textual_enhanced/dialogs/modal_input.py
+++ b/src/textual_enhanced/dialogs/modal_input.py
@@ -51,7 +51,7 @@ class ModalInput(ModalScreen[str | None]):
         yield Input(self._initial, placeholder=self._placeholder)
 
     @on(Input.Submitted)
-    def search(self) -> None:
+    def accept_input(self) -> None:
         """Accept the input."""
         self.dismiss(self.query_one(Input).value.strip())
 


### PR DESCRIPTION
Closes #43.