### PR TITLE
WiP: Surprise markup-safe notifications

### DIFF
--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -10,9 +10,9 @@
 #   universal: false
 
 -e file:.
-aiohappyeyeballs==2.4.4
+aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.11
+aiohttp==3.11.16
     # via aiohttp-jinja2
     # via textual-dev
     # via textual-serve
@@ -20,7 +20,7 @@ aiohttp-jinja2==1.6
     # via textual-serve
 aiosignal==1.3.2
     # via aiohttp
-attrs==25.1.0
+attrs==25.3.0
     # via aiohttp
 babel==2.17.0
     # via mkdocs-material
@@ -40,21 +40,21 @@ colorama==0.4.6
     # via mkdocs-material
 distlib==0.3.9
     # via virtualenv
-filelock==3.17.0
+filelock==3.18.0
     # via virtualenv
 frozenlist==1.5.0
     # via aiohttp
     # via aiosignal
 ghp-import==2.1.0
     # via mkdocs
-griffe==1.6.0
+griffe==1.7.2
     # via mkdocstrings-python
-identify==2.6.6
+identify==2.6.9
     # via pre-commit
 idna==3.10
     # via requests
     # via yarl
-jinja2==3.1.5
+jinja2==3.1.6
     # via aiohttp-jinja2
     # via mkdocs
     # via mkdocs-material
@@ -62,7 +62,7 @@ jinja2==3.1.5
     # via textual-serve
 linkify-it-py==2.0.3
     # via markdown-it-py
-markdown==3.7
+markdown==3.8
     # via mkdocs
     # via mkdocs-autorefs
     # via mkdocs-material
@@ -88,25 +88,24 @@ mkdocs==1.6.1
     # via mkdocs-autorefs
     # via mkdocs-material
     # via mkdocstrings
-mkdocs-autorefs==1.4.0
+mkdocs-autorefs==1.4.1
     # via mkdocstrings
     # via mkdocstrings-python
 mkdocs-get-deps==0.2.0
     # via mkdocs
-    # via mkdocstrings
-mkdocs-material==9.6.7
+mkdocs-material==9.6.11
 mkdocs-material-extensions==1.3.1
     # via mkdocs-material
-mkdocstrings==0.28.2
+mkdocstrings==0.29.1
     # via mkdocstrings-python
-mkdocstrings-python==1.16.2
+mkdocstrings-python==1.16.10
     # via mkdocstrings
 msgpack==1.1.0
     # via textual-dev
-multidict==6.1.0
+multidict==6.4.3
     # via aiohttp
     # via yarl
-mypy==1.14.1
+mypy==1.15.0
 mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.9.1
@@ -117,12 +116,12 @@ paginate==0.5.7
     # via mkdocs-material
 pathspec==0.12.1
     # via mkdocs
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via mkdocs-get-deps
     # via textual
     # via virtualenv
-pre-commit==4.1.0
-propcache==0.2.1
+pre-commit==4.2.0
+propcache==0.3.1
     # via aiohttp
     # via yarl
 pygments==2.19.1
@@ -143,30 +142,30 @@ pyyaml-env-tag==0.1
     # via mkdocs
 requests==2.32.3
     # via mkdocs-material
-rich==13.9.4
+rich==14.0.0
     # via textual
     # via textual-serve
-ruff==0.9.9
+ruff==0.11.5
 six==1.17.0
     # via python-dateutil
-textual==1.0.0
+textual==3.1.0
     # via textual-dev
     # via textual-enhanced
     # via textual-serve
 textual-dev==1.7.0
 textual-serve==1.1.1
     # via textual-dev
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via mypy
     # via textual
     # via textual-dev
 uc-micro-py==1.0.3
     # via linkify-it-py
-urllib3==2.3.0
+urllib3==2.4.0
     # via requests
-virtualenv==20.29.1
+virtualenv==20.30.0
     # via pre-commit
 watchdog==6.0.0
     # via mkdocs
-yarl==1.18.3
+yarl==1.19.0
     # via aiohttp

--- a/requirements.lock
+++ b/requirements.lock
@@ -20,15 +20,15 @@ mdit-py-plugins==0.4.2
     # via markdown-it-py
 mdurl==0.1.2
     # via markdown-it-py
-platformdirs==4.3.6
+platformdirs==4.3.7
     # via textual
 pygments==2.19.1
     # via rich
-rich==13.9.4
+rich==14.0.0
     # via textual
-textual==1.0.0
+textual==3.1.0
     # via textual-enhanced
-typing-extensions==4.12.2
+typing-extensions==4.13.2
     # via textual
 uc-micro-py==1.0.3
     # via linkify-it-py

--- a/src/textual_enhanced/__main__.py
+++ b/src/textual_enhanced/__main__.py
@@ -78,6 +78,7 @@ class Main(EnhancedScreen[None]):
         yield Button("Another input", id="input_with_default")
         yield Button("Yes or no?", id="confirm")
         yield Button("Pick a number", id="number")
+        yield Button("Safe notification", id="notification")
         yield Footer()
 
     @on(Button.Pressed, "#input, #input_with_default")
@@ -112,6 +113,12 @@ class Main(EnhancedScreen[None]):
     @on(ShowNumber)
     def show_the_number(self, number: ShowNumber) -> None:
         self.notify(f"You picked {number.number}")
+
+    @on(Button.Pressed, "#notification")
+    def safe_notification_test(self) -> None:
+        self.notify("Body: [True, False]", title="Title: [True, False]")
+        self.notify("This has [red]colour[/]")
+        self.notify("This has [red]colour[/] and [True, False]")
 
 
 ##############################################################################

--- a/src/textual_enhanced/app.py
+++ b/src/textual_enhanced/app.py
@@ -8,6 +8,9 @@ from typing import Generic
 # Textual imports.
 from textual.app import App, ReturnType
 from textual.binding import Binding
+from textual.content import Content
+from textual.markup import MarkupError
+from textual.notifications import SeverityLevel
 
 
 ##############################################################################
@@ -67,6 +70,51 @@ class EnhancedApp(Generic[ReturnType], App[ReturnType]):
             tooltip="Show the command palette",
         ),
     ]
+
+    def notify(
+        self,
+        message: str,
+        *,
+        title: str = "",
+        severity: SeverityLevel = "information",
+        timeout: float | None = None,
+        markup: bool = True,
+    ) -> None:
+        """Create a notification.
+
+        Args:
+            message: The message for the notification.
+            title: The title for the notification.
+            severity: The severity of the notification.
+            timeout: The timeout (in seconds) for the notification, or `None` for default.
+            markup: Render the message as content markup?
+
+        Notes:
+            See the [Textual docs for `notify`][textual.app.App.notify] for full details.
+
+            This is a markup-safe version of the `notify` method. Textual
+            has changed how it handles markup and has now decided that
+            broken markup should crash your application; imagine if browsers
+            did that! So this is a sensible approach to handling unexpected
+            markup-looking text.
+
+            The `markup` parameter is still used; but if `markup` is
+            [`True`][True] a test call to
+            [`Content.from_markup`][textual.content.Content.from_markup] is
+            performed and, if `MarkupError` is raised `markup` is forced to
+            [`False`][False].
+
+            Surprise markup [should not be the application user's
+            concern](https://en.wikipedia.org/wiki/Principle_of_least_astonishment).
+        """
+        if markup:
+            try:
+                _ = Content.from_markup(message)
+            except MarkupError:
+                markup = False
+        return super().notify(
+            message, title=title, severity=severity, timeout=timeout, markup=markup
+        )
 
 
 ### app.py ends here


### PR DESCRIPTION
Textual now considers unexpected/bad markup to be a runtime error; crashing apps in unexpected ways. This is a curious choice. Folk wouldn't accept this from browsers (and Textual -- at least once upon a time -- wanted to be that platform for the terminal) and it seems odd to make it the app-users' problem in the terminal.

So.. let's experiment with graceful degradation of experience in the face of unexpected markup; rather than just shitting on the user and bailing.

> [!note]
> This is WiP at the moment in that `textual-enhanced` tries to span a few Textual versions and some of what I'm trying to handle here only exists in specific Textual versions. This is a tinker/thought-experiment PR for now.