### PR TITLE
Make `Command` be action-first

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@
 
 - Renamed `ModalInput.search` to `ModalInput.accept_input`.
   ([#43](https://github.com/davep/textual-enhanced/issues/43))
+- A `Command`, invoked either by the command palette or by a binding, will
+  now always invoke its action; it's no longer necessary to use `@on` as
+  well as define the `action_*_command` function.
+- A `Command` can now have an `ACTION` that is an inline action; it's no
+  longer necessary to define one `action_*_command` per command (eg: a
+  `Quit` command can set its `ACTION` to `"app.quit"`, etc).
 
 ## v0.11.0
 

--- a/src/textual_enhanced/commands/common.py
+++ b/src/textual_enhanced/commands/common.py
@@ -27,6 +27,7 @@ class Quit(Command):
 
     BINDING_KEY = "f10, ctrl+q"
     SHOW_IN_FOOTER = True
+    ACTION = "app.quit"
 
 
 ##############################################################################

--- a/src/textual_enhanced/screen.py
+++ b/src/textual_enhanced/screen.py
@@ -6,13 +6,12 @@ from typing import Generic
 
 ##############################################################################
 # Textual imports.
-from textual import on
 from textual.command import CommandPalette
 from textual.screen import Screen, ScreenResultType
 
 ##############################################################################
 # Local imports.
-from .commands import ChangeTheme, CommandsProvider, Help, Quit
+from .commands import CommandsProvider
 from .dialogs import HelpScreen
 
 
@@ -33,7 +32,6 @@ class EnhancedScreen(Generic[ScreenResultType], Screen[ScreenResultType]):
             )
         )
 
-    @on(Help)
     def action_help_command(self) -> None:
         """Show the help screen.
 
@@ -42,15 +40,9 @@ class EnhancedScreen(Generic[ScreenResultType], Screen[ScreenResultType]):
         """
         self.app.push_screen(HelpScreen(self))
 
-    @on(ChangeTheme)
     def action_change_theme_command(self) -> None:
         """Show the Textual theme picker command palette."""
         self.app.search_themes()
-
-    @on(Quit)
-    def action_quit_command(self) -> None:
-        """Quit the application."""
-        self.app.exit()
 
 
 ### screen.py ends here


### PR DESCRIPTION
This change means that there's little to no need to ever decorate a command action with `@on` any more; and also a Command can call on a specific action "inline" (so this should then allow multiple commands to call on a single action using parameters, etc).