### PR TITLE
Change Header flair removal to try and nuke a new flash

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,8 @@
   ([#53](https://github.com/davep/textual-enhanced/pull/53))
 - Added Python 3.14 as a tested/supported Python version.
   ([#54](https://github.com/davep/textual-enhanced/pull/54))
+- Tightened up the remove of Textual's `Header` flair because Textual 6.x or
+  so made it worse.
 
 ## v0.13.0
 

--- a/src/textual_enhanced/__main__.py
+++ b/src/textual_enhanced/__main__.py
@@ -7,7 +7,8 @@ from dataclasses import dataclass
 ##############################################################################
 # Textual imports.
 from textual import on, work
-from textual.app import ComposeResult
+from textual.app import ComposeResult, RenderResult
+from textual.containers import Horizontal
 from textual.message import Message
 from textual.widgets import Button, Footer, Header
 
@@ -57,12 +58,14 @@ class SayTwo(Command):
     ACTION = "say('Two')"
 
 
+##############################################################################
 class OtherCommands(CommandsProvider):
     def commands(self) -> CommandHits:
         yield SayOne()
         yield SayTwo()
 
 
+##############################################################################
 class HelpfulButton(Button):
     BINDINGS = [
         HelpfulBinding("ctrl+o", "gndn", description="This does nothing useful")
@@ -70,7 +73,23 @@ class HelpfulButton(Button):
 
 
 ##############################################################################
+class Ruler(Horizontal):
+    DEFAULT_CSS = """
+    Ruler {
+        width: 1fr;
+        height: 1;
+        text-align: center;
+    }
+    """
+
+    def render(self) -> RenderResult:
+        return "----- | -----"
+
+
+##############################################################################
 class Main(EnhancedScreen[None]):
+    TITLE = "Title"
+    SUB_TITLE = "Title"
     COMMAND_MESSAGES = (Help, ChangeTheme, Quit)
     COMMANDS = {CommonCommands, OtherCommands}
     BINDINGS = Command.bindings(
@@ -90,6 +109,7 @@ class Main(EnhancedScreen[None]):
 
     def compose(self) -> ComposeResult:
         yield Header()
+        yield Ruler()
         yield HelpfulButton("Quick input", id="input")
         yield Button("Another input", id="input_with_default")
         yield Button("Yes or no?", id="confirm")

--- a/src/textual_enhanced/app.py
+++ b/src/textual_enhanced/app.py
@@ -40,9 +40,9 @@ class EnhancedApp(Generic[ReturnType], App[ReturnType]):
 
     /* Remove cruft from the Header. */
     Header {
-        /* The header icon serves no useful purpose. Remove it. */
-        HeaderIcon {
-            visibility: hidden;
+        /* I have zero use for the header icon or the clock. */
+        HeaderIcon, HeaderClockSpace {
+            display: none;
         }
 
         /* Ditto the tall version of the header. Nuke that. */


### PR DESCRIPTION
Kicking off around Textual 6.0.0 or so, if I have an app that takes a moment to really let its UI settle down, I'm seeing this flash of a dead zone in the header:

![header-flash](https://github.com/user-attachments/assets/38633179-df00-429d-9b9e-4a5cbdc2c07f)

There seems to have been some changes to the `Header`, and of course the usual round of "optimisations", so who knows what might have borked actual real apps again...

Anyway, here's a tweak to how I nuke header flair I don't need in the hope that it stop this from happening.

![facepalm-stressed](https://github.com/user-attachments/assets/b780ac43-6ef4-44e3-accd-709dfcdb692d)

The PR also updates the test application to help ensure that the title is always in the middle of the display.