### PR TITLE
Reinstate the command palette's borders standing out

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # textual-enhanced ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Tweaked the borders of the command palette so they stand out like they
+  used to.
+
 ## v1.0.0
 
 **Released: 2025-08-05**

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 **Released: WiP**
 
 - Tweaked the borders of the command palette so they stand out like they
-  used to.
+  used to. ([#59](https://github.com/davep/textual-enhanced/pull/59))
 
 ## v1.0.0
 

--- a/src/textual_enhanced/app.py
+++ b/src/textual_enhanced/app.py
@@ -23,10 +23,14 @@ class EnhancedApp(Generic[ReturnType], App[ReturnType]):
     CommandPalette > Vertical {
         width: 75%; /* Full-width command palette looks kinda unfinished. Fix that. */
         background: $panel;
+        #--input {
+            border-top: hkey $border;
+        }
         OptionList{
             scrollbar-background: $panel;
             scrollbar-background-hover: $panel;
             scrollbar-background-active: $panel;
+            border-bottom: hkey $border;
         }
         SearchIcon {
             display: none;


### PR DESCRIPTION
At some point in the past the command palette's top/bottom borders seem to have been made a hard black; a curious choice that doesn't really fit in with themes.

This goes back to using something a little more sensible and sensitive to the theme.