### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -1,5 +1,8 @@
 name: Code quality tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/davep/textual-enhanced/security/code-scanning/1](https://github.com/davep/textual-enhanced/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For a code-quality workflow that only needs to read the repository contents, `contents: read` at the workflow or job level is sufficient. This ensures the workflow does not inherit broader default permissions from the repository or organization settings.

The best way to fix this specific workflow without changing functionality is to add `permissions: contents: read` at the workflow root, so it applies to all jobs (currently just `style-lint-and-test`). This keeps the job behavior unchanged (it only needs to read code and install dependencies) while constraining the token. Concretely, edit `.github/workflows/code-checks.yaml` near the top: after the `name: Code quality tests` line, insert a `permissions:` block. No imports or additional methods are needed, as this is pure GitHub Actions YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
